### PR TITLE
fix #2, add leading zeroes in dictionary key

### DIFF
--- a/AudioTools/Scripts/Runtime/Extensions/SpatialAudioSystem/SpatialAudioManager.cs
+++ b/AudioTools/Scripts/Runtime/Extensions/SpatialAudioSystem/SpatialAudioManager.cs
@@ -803,7 +803,7 @@ namespace FMODUnityTools
 
                         uint roomA_ID = roomUniqueIDs[roomA];
                         uint roomB_ID = roomUniqueIDs[roomB];
-                        string roomPairID = roomA_ID.ToString() + roomB_ID.ToString();
+                        string roomPairID = roomA_ID.ToString("D2") + roomB_ID.ToString("D2");
 
                         if (relevantRoomPairsByRoom.ContainsKey(roomA))
                         {


### PR DESCRIPTION
Simple fix for issue #2, adds leading zeroes for any dict indexes which were previously only expressed by a single digit, such as "1" "2" etc. This previously led to duplicate dict indexes, when you combine "1" and "11"  vs. "11" and "1", for instance.

I believe this fixes the issue I was having, but I have not tested thoroughly for other unintended consequences.