### PR TITLE
clamp scaledRolloff to >= 0

### DIFF
--- a/AudioTools/Scripts/Runtime/Extensions/SpatialAudioSystem/SpatialAudioManager.cs
+++ b/AudioTools/Scripts/Runtime/Extensions/SpatialAudioSystem/SpatialAudioManager.cs
@@ -1016,6 +1016,9 @@ namespace FMODUnityTools
             float difference = routeLength - directRouteLength;
             float scaledRolloff = instance.maxDistance - difference;
 
+            // Clamp the scaledRolloff to make sure it's never negative
+            scaledRolloff = Mathf.Max(scaledRolloff, 0f);
+
             if (instance.eventInstance.isValid())
             {
                 var result = instance.eventInstance.setProperty(EVENT_PROPERTY.MAXIMUM_DISTANCE, scaledRolloff);


### PR DESCRIPTION
Solves issue:

> [FMOD] assert : assertion: 'value >= 0.0f || value == -1.0f' failed
> 
> UnityEngine.Debug:LogError (object)
> FMODUnity.RuntimeUtils:DebugLogError (string) (at Assets/Plugins/FMOD/src/RuntimeUtils.cs:585)
> FMODUnity.RuntimeManager:DEBUG_CALLBACK (FMOD.DEBUG_FLAGS,intptr,int,intptr,intptr) (at Assets/Plugins/FMOD/src/RuntimeManager.cs:90)
> FMOD.Studio.EventInstance:setProperty (FMOD.Studio.EVENT_PROPERTY,single) (at Assets/Plugins/FMOD/src/fmod_studio.cs:1353)
> FMODUnityTools.SpatialAudioManager:ScaleRolloffDistance (single,single,FMODUnityTools.SpatialAudioManager/RoomAwareInstance) (at Assets/Plugins/AudioTools/Scripts/Runtime/Extensions/SpatialAudioSystem/SpatialAudioManager.cs:1075)
> FMODUnityTools.SpatialAudioManager:CalculatePropagationCosts (System.Collections.Generic.List`1<FMODUnityTools.SpatialAudioManager/RoomAwareInstance>) (at Assets/Plugins/AudioTools/Scripts/Runtime/Extensions/SpatialAudioSystem/SpatialAudioManager.cs:952)
> FMODUnityTools.SpatialAudioManager:LateUpdate () (at Assets/Plugins/AudioTools/Scripts/Runtime/Extensions/SpatialAudioSystem/SpatialAudioManager.cs:405)

This was reproducible in a two-story structure, for instance, when the listener is directly above an emitter; when the listener is still within the max distance of the sound but instance.maxDistance - difference results in a negative number.

In other words, adding a clamp function solves the edge case where the extra distance of passing thru the room-portal network is greater than the original max distance of the sound, but you're still within the original "bird's eye" range of the sound.