### PR TITLE
fix il2cpp bug

### DIFF
--- a/AudioTools/Scripts/Runtime/Core/Utility/HelperMethods.cs
+++ b/AudioTools/Scripts/Runtime/Core/Utility/HelperMethods.cs
@@ -15,7 +15,7 @@ namespace FMODUnityTools
             if (collider == null)
                 return false;
 
-            return (collider.ClosestPoint(position) - position).sqrMagnitude < Mathf.Epsilon * Mathf.Epsilon;
+            return Mathf.Approximately((collider.ClosestPoint(position) - position).magnitude, 0);
         }
 
         public static bool GetIfLayerMaskContainsLayer(int layer, LayerMask layerMask)


### PR DESCRIPTION
The line
> return (collider.ClosestPoint(position) - position).sqrMagnitude < Mathf.Epsilon * Mathf.Epsilon;

Returns `null` in il2cpp builds but not mono builds. Likely a floating point rounding error, and this code solves it, by seeing if the two values are within epsilon of each other.